### PR TITLE
fix(worker): enhance error handling during save operations

### DIFF
--- a/pegaflow-core/src/transfer.rs
+++ b/pegaflow-core/src/transfer.rs
@@ -112,7 +112,6 @@ pub(crate) fn copy_cpu_to_gpu_async(
     Ok(())
 }
 
-
 /// Batch copy segments from CPU to GPU by finding and merging contiguous ranges
 pub(crate) fn batch_copy_segments_to_gpu(
     transfers: &[(usize, *const u8)],

--- a/pegaflow-server/src/registry.rs
+++ b/pegaflow-server/src/registry.rs
@@ -47,7 +47,9 @@ impl CudaTensorRegistry {
             let torch = py.import("torch")?;
             let cuda = torch.getattr("cuda")?;
             cuda.call_method0("init")?;
-            Ok(Self { contexts: HashMap::new() })
+            Ok(Self {
+                contexts: HashMap::new(),
+            })
         })
     }
 

--- a/python/pegaflow/ipc_wrapper.py
+++ b/python/pegaflow/ipc_wrapper.py
@@ -3,8 +3,12 @@
 This module provides a wrapper class for PyTorch tensors that enables
 cross-process GPU memory sharing via CUDA IPC handles. The wrapper can
 be serialized (via pickle) and sent across process boundaries.
+
+This implementation handles CUDA_VISIBLE_DEVICES correctly by using GPU UUIDs
+instead of device indices for device identification.
 """
 
+import threading
 import torch
 from typing import Tuple
 
@@ -13,13 +17,14 @@ class CudaIPCWrapper:
     """Wrapper for CUDA IPC handle with tensor metadata.
     
     This class wraps a PyTorch CUDA tensor and extracts its IPC handle,
-    allowing the tensor to be reconstructed in another process.
+    allowing the tensor to be reconstructed in another process. It correctly
+    handles CUDA_VISIBLE_DEVICES by using GPU UUIDs for device identification.
     
     Attributes:
         handle: CUDA IPC handle tuple (device, ipc_handle, size, offset, ...)
         dtype: PyTorch dtype of the tensor
         shape: Shape tuple of the tensor
-        device: CUDA device index
+        device_uuid: UUID string of the GPU device
     
     Example:
         # Process 1 (sender)
@@ -33,6 +38,66 @@ class CudaIPCWrapper:
         tensor = wrapper.to_tensor()  # Reconstruct tensor
         ptr = tensor.data_ptr()  # Get GPU pointer
     """
+    
+    # Class-level cache for device UUID to index mapping
+    _discovered_device_mapping: dict[str, int] = {}
+    _device_mapping_lock = threading.Lock()
+    
+    @staticmethod
+    def _get_device_uuid(device_index: int) -> str:
+        """Get the UUID of a GPU device given its index.
+        
+        Args:
+            device_index: CUDA device index (relative to CUDA_VISIBLE_DEVICES)
+        
+        Returns:
+            UUID string of the GPU device
+        """
+        return str(torch.cuda.get_device_properties(device_index).uuid)
+    
+    @staticmethod
+    def _discover_gpu_devices():
+        """Discover all available GPU devices and map their UUIDs to
+        the physical device ordinals (relative to CUDA_VISIBLE_DEVICES).
+        """
+        if not torch.cuda.is_available():
+            return
+        
+        num_devices = torch.cuda.device_count()
+        with CudaIPCWrapper._device_mapping_lock:
+            if CudaIPCWrapper._discovered_device_mapping:
+                return  # Already discovered
+            
+            for i in range(num_devices):
+                device_uuid = CudaIPCWrapper._get_device_uuid(i)
+                CudaIPCWrapper._discovered_device_mapping[device_uuid] = i
+    
+    @staticmethod
+    def _get_device_index_from_uuid(device_uuid: str) -> int:
+        """Get the physical device ordinal from its UUID.
+        
+        Args:
+            device_uuid: UUID string of the GPU device
+        
+        Returns:
+            Device index relative to CUDA_VISIBLE_DEVICES
+        
+        Raises:
+            RuntimeError: If the device UUID is not found
+        """
+        CudaIPCWrapper._discover_gpu_devices()
+        
+        with CudaIPCWrapper._device_mapping_lock:
+            device_index = CudaIPCWrapper._discovered_device_mapping.get(
+                device_uuid, None
+            )
+        
+        if device_index is None:
+            raise RuntimeError(
+                f"Device UUID {device_uuid} not found in the discovered devices. "
+                "Please make sure the process can see all the GPU devices."
+            )
+        return device_index
     
     def __init__(self, tensor: torch.Tensor):
         """Create IPC wrapper from a CUDA tensor.
@@ -55,7 +120,10 @@ class CudaIPCWrapper:
         self.handle = handle
         self.dtype = tensor.dtype
         self.shape = tensor.shape
-        self.device = tensor.device.index
+        
+        # Store device UUID instead of device index to handle CUDA_VISIBLE_DEVICES
+        device_index = tensor.device.index
+        self.device_uuid = CudaIPCWrapper._get_device_uuid(device_index)
     
     def to_tensor(self) -> torch.Tensor:
         """Reconstruct tensor from IPC handle.
@@ -69,12 +137,15 @@ class CudaIPCWrapper:
         Note:
             The reconstructed tensor shares memory with the original. Any
             modifications to one will be visible in the other.
+            
+            This function may break if torch.cuda is not initialized.
+            Call torch.cuda.init() before using this function if needed.
         """
-        # Reconstruct storage from IPC handle
-        storage = torch.UntypedStorage._new_shared_cuda(*self.handle)
+        # Get the correct device index in the current process based on UUID
+        device = CudaIPCWrapper._get_device_index_from_uuid(self.device_uuid)
         
-        # Get device from handle
-        device = self.handle[0]
+        # Reconstruct storage from IPC handle
+        storage = torch.UntypedStorage._new_shared_cuda(device, *self.handle[1:])
         
         # Create empty tensor on the correct device
         t = torch.tensor([], device=device, dtype=self.dtype)
@@ -85,9 +156,27 @@ class CudaIPCWrapper:
         # Reshape to original shape
         return t.view(self.shape)
     
+    def __eq__(self, other) -> bool:
+        """Check equality with another CudaIPCWrapper.
+        
+        Args:
+            other: Object to compare with
+        
+        Returns:
+            True if the wrappers refer to the same tensor, False otherwise
+        """
+        if not isinstance(other, CudaIPCWrapper):
+            return False
+        return (
+            self.handle == other.handle
+            and self.dtype == other.dtype
+            and self.shape == other.shape
+            and self.device_uuid == other.device_uuid
+        )
+    
     def __repr__(self) -> str:
         return (f"CudaIPCWrapper(shape={self.shape}, dtype={self.dtype}, "
-                f"device={self.device})")
+                f"device_uuid={self.device_uuid})")
 
 
 __all__ = ["CudaIPCWrapper"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -190,8 +190,6 @@ impl PegaEngine {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
-
-
     /// Count how many blocks from the prefix are available in CPU storage
     ///
     /// Returns the number of contiguous blocks available from the start.


### PR DESCRIPTION
- Refactored the save operation in WorkerConnector to include try-except blocks for improved error handling.
- Added logging for both successful saves and errors, ensuring that failures do not halt execution.
- Ensured that the layer counter is decremented regardless of save success, maintaining resource management integrity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve worker device IDs under CUDA_VISIBLE_DEVICES and switch CUDA IPC to GPU UUIDs; wrap save RPC in robust error handling while ensuring progress.
> 
> - **CUDA IPC** (`python/pegaflow/ipc_wrapper.py`):
>   - Use GPU UUIDs instead of device indices for IPC (`device_uuid`), with discovery/cache and UUID→device mapping.
>   - Reconstruct tensors using mapped device index; add `__eq__` and updated `__repr__`.
> - **Connector** (`python/pegaflow/connector/__init__.py`):
>   - Add `_resolve_device_id()` to map local CUDA index to global ID via `CUDA_VISIBLE_DEVICES`; use for worker `device_id`.
> - **Worker Save Path** (`python/pegaflow/connector/worker.py`):
>   - Wrap `engine_client.save(...)` in try/except; log failures and continue.
>   - Always decrement layer counters to release blocks even on save failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91329f0c0614eef23c853905599025ffa801967c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->