### PR TITLE
fix: when async loading hit more tokens

### DIFF
--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -230,15 +230,18 @@ class PegaConnectorMetadata(KVConnectorMetadata):
         self,
         load_intents: dict[str, LoadIntent] | None = None,
         save_intents: dict[str, SaveIntent] | None = None,
+        finished_requests: set[str] | None = None,
     ):
         super().__init__()
         # Maps request_id -> intent
         self.load_intents: dict[str, LoadIntent] = load_intents or {}
         self.save_intents: dict[str, SaveIntent] = save_intents or {}
+        # Requests that have finished generation and are waiting for save to complete
+        self.finished_requests: set[str] = finished_requests or set()
 
     def __repr__(self) -> str:
         return (f"PegaConnectorMetadata(loads={len(self.load_intents)}, "
-                f"saves={len(self.save_intents)})")
+                f"saves={len(self.save_intents)}, finished={len(self.finished_requests)})")
 
 
 def resolve_instance_id(vllm_config, dp_rank_suffix: bool = True) -> str:

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -97,12 +97,25 @@ class SchedulerConnector:
             load_intent = tracker.consume_load_intent()
             if load_intent is not None:
                 self._pending_load_intents[req_id] = load_intent
-                logger.debug(
+                logger.info(
                     "[PegaKVConnector] update_state_after_alloc req=%s created LoadIntent: "
                     "%d blocks, %d tokens",
                     req_id,
                     len(load_intent.block_ids),
                     load_intent.num_tokens,
+                )
+            else:
+                logger.warning(
+                    "[PegaKVConnector] update_state_after_alloc req=%s external_tokens=%d "
+                    "but NO LoadIntent created (loaded_blocks=%d, needs_load=%s, "
+                    "hit_blocks=%d, allocated=%d, computed=%d)",
+                    req_id,
+                    num_external_tokens,
+                    tracker._loaded_blocks,
+                    tracker._needs_load,
+                    tracker._hit_blocks,
+                    len(tracker._allocated_blocks),
+                    tracker._computed_blocks,
                 )
 
         logger.debug(

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -104,7 +104,8 @@ class SchedulerConnector:
                     len(load_intent.block_ids),
                     load_intent.num_tokens,
                 )
-            else:
+            elif tracker._loaded_blocks < tracker._hit_blocks:
+                # Only warn if we expected to load more blocks but couldn't
                 logger.warning(
                     "[PegaKVConnector] update_state_after_alloc req=%s external_tokens=%d "
                     "but NO LoadIntent created (loaded_blocks=%d, needs_load=%s, "
@@ -116,6 +117,14 @@ class SchedulerConnector:
                     tracker._hit_blocks,
                     len(tracker._allocated_blocks),
                     tracker._computed_blocks,
+                )
+            else:
+                # All available blocks already loaded - this is expected for subsequent calls
+                logger.debug(
+                    "[PegaKVConnector] update_state_after_alloc req=%s all %d hit blocks "
+                    "already loaded",
+                    req_id,
+                    tracker._loaded_blocks,
                 )
 
         logger.debug(

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -73,7 +73,11 @@ class SchedulerConnector:
             req_id,
         )
 
-        return (num_hit_tokens, True)
+        # If we've already scheduled loading these blocks, return False
+        # to indicate no NEW async loading is needed
+        needs_async_load = tracker._loaded_blocks < hit_blocks
+
+        return (num_hit_tokens, needs_async_load)
 
     @timing_wrapper
     def update_state_after_alloc(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Track loaded KV blocks to drive async load decisions, pass finished requests to worker, and refine save/load completion logic with clearer logging.
> 
> - **Core/common (`common.py`)**:
>   - Add load tracking via `_loaded_blocks`; remove `_load_consumed` flag.
>   - Update `phase` to report `LOADING` until `loaded_blocks >= hit_blocks`.
>   - Revise `consume_load_intent` to load only new ranges and advance `_loaded_blocks`.
>   - Extend `PegaConnectorMetadata` with `finished_requests`.
>   - Improve `RequestTracker.__repr__` to include `loaded`.
> - **Scheduler (`scheduler.py`)**:
>   - `get_num_new_matched_tokens` now returns whether new async load is needed based on `_loaded_blocks < hit_blocks`.
>   - In `update_state_after_alloc`, create `LoadIntent` when available; warn if expected load not created; add info/debug logs.
>   - `build_connector_meta` now includes `finished_requests` and logs held count.
>   - On connector output, remove held requests on save completion and finalize tracker state.
> - **Worker (`worker.py`)**:
>   - Track scheduler-provided `finished_requests` to release saves when done.
>   - Enhance `get_finished` to emit completed saves for finished/held requests and report async load completions; richer diagnostics.
>   - `start_load_kv` records `finished_requests` and logs async load with request IDs.
>   - Add detailed logging for save start/end and guardrails in layer counter decrement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be672846fcb9fb7319649a2e9e32530ec2989c92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->