### PR TITLE
feat(storage): add pre-eviction configuration and background thread

### DIFF
--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod sync_state;
 mod transfer;
 
 pub use pinned_pool::PinnedAllocation;
+pub use storage::PreEvictConfig;
 pub use sync_state::{LoadState, LoadStateError};
 
 // ============================================================================
@@ -269,7 +270,18 @@ impl PegaEngine {
     ///
     /// If `use_hugepages` is true, uses 2MB huge pages (requires system config).
     pub fn new_with_pool_size(pool_size: usize, use_hugepages: bool) -> Self {
-        let storage = StorageEngine::new(pool_size, use_hugepages);
+        Self::new_with_config(pool_size, use_hugepages, storage::PreEvictConfig::default())
+    }
+
+    /// Create a new PegaEngine instance with custom pool size and pre-eviction config
+    ///
+    /// If `use_hugepages` is true, uses 2MB huge pages (requires system config).
+    pub fn new_with_config(
+        pool_size: usize,
+        use_hugepages: bool,
+        pre_evict_config: storage::PreEvictConfig,
+    ) -> Self {
+        let storage = StorageEngine::new_with_config(pool_size, use_hugepages, pre_evict_config);
         PegaEngine {
             instances: RwLock::new(HashMap::new()),
             storage,

--- a/pegaflow-core/src/storage.rs
+++ b/pegaflow-core/src/storage.rs
@@ -347,14 +347,12 @@ impl LayerBlock {
         self.size
     }
 
-    /// Total pinned memory occupied by this layer block (K + V if split).
+    /// Total pinned memory occupied by this layer block.
+    ///
+    /// For both contiguous and split layouts, `self.size` holds `block_size_bytes`
+    /// which equals `bytes_per_block * segments` (the total K+V size).
     pub fn memory_footprint(&self) -> u64 {
-        let k_bytes = self.size as u64;
-        if self.v_allocation.is_some() {
-            k_bytes * 2 // Split storage: K and V each occupy `size` bytes
-        } else {
-            k_bytes // Contiguous: single allocation
-        }
+        self.size as u64
     }
 }
 

--- a/pegaflow-core/src/storage.rs
+++ b/pegaflow-core/src/storage.rs
@@ -7,6 +7,8 @@ use crossbeam::sync::ShardedLock;
 //   utilization levels). On failure we drop a batch of LRU entries and retry.
 // - Eviction is batched (RECLAIM_BATCH_OBJECTS) so a single allocation failure
 //   can free multiple cached objects at once instead of thrashing.
+// - Pre-eviction: A background thread can be enabled to proactively reclaim
+//   blocks when free space drops below a threshold, reducing allocation stalls.
 // - LRU key: BlockHash (Vec<u8> digest for one logical block across layers/TP ranks).
 //   LRU value: Block (stateful set of LayerBlock slots, ordered by flat slot id
 //   slot_id = layer_id * tp_size + tp_rank).
@@ -22,13 +24,51 @@ use bytesize::ByteSize;
 use hashlink::LruCache;
 use std::fmt;
 use std::num::NonZeroU64;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use tracing::{debug, error};
+use std::thread::JoinHandle;
+use std::time::Duration;
+use tracing::{debug, error, info};
 
 use crate::metrics::core_metrics;
 use crate::pinned_pool::{PinnedAllocation, PinnedMemoryPool};
 
 const RECLAIM_BATCH_OBJECTS: usize = 4096;
+
+/// Configuration for pre-eviction monitoring thread.
+#[derive(Debug, Clone)]
+pub struct PreEvictConfig {
+    /// Enable pre-eviction background thread
+    pub enabled: bool,
+    /// Start evicting when free space drops below this threshold (bytes)
+    pub threshold_bytes: u64,
+    /// Target free space after eviction completes (bytes)
+    pub target_bytes: u64,
+    /// How often to check pool usage (milliseconds)
+    pub check_interval_ms: u64,
+}
+
+impl Default for PreEvictConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            threshold_bytes: 5 * 1024 * 1024 * 1024, // 5GB
+            target_bytes: 8 * 1024 * 1024 * 1024,    // 8GB
+            check_interval_ms: 100,
+        }
+    }
+}
+
+impl PreEvictConfig {
+    pub fn new(threshold_bytes: u64, target_bytes: u64, check_interval_ms: u64) -> Self {
+        Self {
+            enabled: true,
+            threshold_bytes,
+            target_bytes,
+            check_interval_ms,
+        }
+    }
+}
 
 // A "slot" in this file refers to a specific position in the flattened logical storage,
 // calculated as `layer_id * tp_size + tp_rank`.
@@ -74,6 +114,7 @@ struct FillingBlock {
     slots: LayerBlockSlots,
     remaining: usize,
     total_slots: usize,
+    footprint: u64,
 }
 
 impl FillingBlock {
@@ -82,6 +123,7 @@ impl FillingBlock {
             slots: vec![None; total_slots],
             remaining: total_slots,
             total_slots,
+            footprint: 0,
         }
     }
 
@@ -120,6 +162,7 @@ impl FillingBlock {
             return Err(BlockInsertError::SlotAlreadyFilled { slot_id });
         }
 
+        self.footprint += block.memory_footprint();
         self.slots[slot_id] = Some(block);
         self.remaining = self
             .remaining
@@ -132,6 +175,7 @@ impl FillingBlock {
 /// Immutable view after all slots are filled; no further writes allowed.
 struct SealedBlock {
     slots: Arc<[Arc<LayerBlock>]>,
+    footprint: u64,
 }
 
 impl SealedBlock {
@@ -163,6 +207,7 @@ impl BlockState {
                         .collect();
                     *self = BlockState::Sealed(SealedBlock {
                         slots: sealed_slots.into(),
+                        footprint: filling.footprint,
                     });
                 }
                 Ok(())
@@ -187,6 +232,14 @@ impl BlockState {
 
     fn is_complete(&self) -> bool {
         matches!(self, BlockState::Sealed(_))
+    }
+
+    /// Total pinned memory occupied by all filled slots (O(1), cached on insert).
+    fn memory_footprint(&self) -> u64 {
+        match self {
+            BlockState::Filling(f) => f.footprint,
+            BlockState::Sealed(s) => s.footprint,
+        }
     }
 }
 
@@ -225,6 +278,14 @@ impl Block {
     pub fn is_complete(&self) -> bool {
         let state = self.inner.read().expect("block entry lock poisoned");
         state.is_complete()
+    }
+
+    /// Total pinned memory occupied by this block (sum of all filled slots).
+    pub fn memory_footprint(&self) -> u64 {
+        self.inner
+            .read()
+            .expect("block lock poisoned")
+            .memory_footprint()
     }
 }
 
@@ -285,6 +346,16 @@ impl LayerBlock {
     pub fn size(&self) -> usize {
         self.size
     }
+
+    /// Total pinned memory occupied by this layer block (K + V if split).
+    pub fn memory_footprint(&self) -> u64 {
+        let k_bytes = self.size as u64;
+        if self.v_allocation.is_some() {
+            k_bytes * 2 // Split storage: K and V each occupy `size` bytes
+        } else {
+            k_bytes // Contiguous: single allocation
+        }
+    }
 }
 
 // Safety: pinned memory ownership is tracked by Arc counters on the allocations.
@@ -292,18 +363,46 @@ unsafe impl Send for LayerBlock {}
 unsafe impl Sync for LayerBlock {}
 
 pub struct StorageEngine {
-    kv_storage: Mutex<LruCache<BlockKey, Arc<Block>>>,
+    kv_storage: Arc<Mutex<LruCache<BlockKey, Arc<Block>>>>,
     pinned_pool: Arc<PinnedMemoryPool>,
+    pre_evict_stop: Arc<AtomicBool>,
+    pre_evict_handle: Option<JoinHandle<()>>,
 }
 
 impl StorageEngine {
-    pub fn new(capacity_bytes: usize, use_hugepages: bool) -> Self {
+    pub fn new_with_config(
+        capacity_bytes: usize,
+        use_hugepages: bool,
+        config: PreEvictConfig,
+    ) -> Self {
         let pinned_pool = Arc::new(PinnedMemoryPool::new(capacity_bytes, use_hugepages));
-        let kv_storage = Mutex::new(LruCache::new_unbounded());
+        let kv_storage = Arc::new(Mutex::new(LruCache::new_unbounded()));
+        let pre_evict_stop = Arc::new(AtomicBool::new(false));
+
+        let pre_evict_handle = if config.enabled {
+            info!(
+                "Starting pre-eviction monitor: threshold={}, target={}, interval={}ms",
+                ByteSize(config.threshold_bytes),
+                ByteSize(config.target_bytes),
+                config.check_interval_ms
+            );
+
+            let pool = Arc::clone(&pinned_pool);
+            let cache = Arc::clone(&kv_storage);
+            let stop = Arc::clone(&pre_evict_stop);
+
+            Some(std::thread::spawn(move || {
+                Self::pre_evict_monitor(pool, cache, config, stop);
+            }))
+        } else {
+            None
+        };
 
         Self {
             kv_storage,
             pinned_pool,
+            pre_evict_stop,
+            pre_evict_handle,
         }
     }
 
@@ -331,19 +430,28 @@ impl StorageEngine {
     }
 
     fn reclaim(&self, target_objects: usize) -> usize {
+        Self::reclaim_from_cache_by_count(&self.kv_storage, target_objects)
+    }
+
+    /// Reclaim blocks from the cache by count. Returns the number of blocks evicted.
+    fn reclaim_from_cache_by_count(
+        cache: &Mutex<LruCache<BlockKey, Arc<Block>>>,
+        target_objects: usize,
+    ) -> usize {
         if target_objects == 0 {
             return 0;
         }
 
         let mut freed_entries = 0;
-        let mut cache = self.kv_storage.lock().unwrap();
+        let mut cache_lock = cache.lock().unwrap();
 
         while freed_entries < target_objects {
-            let Some((_hash, _layer_blocks)) = cache.remove_lru() else {
+            let Some((_hash, _layer_blocks)) = cache_lock.remove_lru() else {
                 break;
             };
             freed_entries += 1;
         }
+        drop(cache_lock);
 
         if freed_entries > 0 {
             debug!(freed_entries, "Reclaimed blocks from cache");
@@ -353,6 +461,85 @@ impl StorageEngine {
         }
 
         freed_entries
+    }
+
+    /// Reclaim blocks from the cache by target bytes. Returns (blocks_freed, bytes_freed).
+    fn reclaim_from_cache_by_bytes(
+        cache: &Mutex<LruCache<BlockKey, Arc<Block>>>,
+        target_bytes: u64,
+    ) -> (usize, u64) {
+        if target_bytes == 0 {
+            return (0, 0);
+        }
+
+        let mut freed_blocks = 0;
+        let mut freed_bytes = 0u64;
+        let mut cache_lock = cache.lock().unwrap();
+
+        while freed_bytes < target_bytes {
+            let Some((_hash, block)) = cache_lock.remove_lru() else {
+                break;
+            };
+
+            freed_bytes += block.memory_footprint();
+            freed_blocks += 1;
+        }
+        drop(cache_lock);
+
+        if freed_blocks > 0 {
+            debug!(
+                freed_blocks,
+                freed_bytes = ByteSize(freed_bytes).to_string(),
+                "Reclaimed blocks from cache"
+            );
+            core_metrics()
+                .cache_block_evictions
+                .add(freed_blocks as u64, &[]);
+        }
+
+        (freed_blocks, freed_bytes)
+    }
+
+    fn pre_evict_monitor(
+        pool: Arc<PinnedMemoryPool>,
+        cache: Arc<Mutex<LruCache<BlockKey, Arc<Block>>>>,
+        config: PreEvictConfig,
+        stop: Arc<AtomicBool>,
+    ) {
+        let interval = Duration::from_millis(config.check_interval_ms);
+
+        while !stop.load(Ordering::Relaxed) {
+            std::thread::sleep(interval);
+
+            let (used, total) = pool.usage();
+            let free = total.saturating_sub(used);
+
+            if free < config.threshold_bytes {
+                let target_free = config.target_bytes;
+                let need_free = target_free.saturating_sub(free);
+
+                debug!(
+                    free = ByteSize(free).to_string(),
+                    threshold = ByteSize(config.threshold_bytes).to_string(),
+                    target = ByteSize(target_free).to_string(),
+                    need_free = ByteSize(need_free).to_string(),
+                    "Pre-eviction triggered"
+                );
+
+                let (freed_blocks, freed_bytes) =
+                    Self::reclaim_from_cache_by_bytes(&cache, need_free);
+
+                if freed_blocks > 0 {
+                    info!(
+                        freed_blocks,
+                        freed_bytes = ByteSize(freed_bytes).to_string(),
+                        "Pre-eviction completed"
+                    );
+                }
+            }
+        }
+
+        debug!("Pre-eviction monitor thread stopped");
     }
 
     pub fn slot_has_block(&self, namespace: &str, block_hash: &[u8], slot_id: usize) -> bool {
@@ -411,6 +598,21 @@ impl StorageEngine {
             result.push(shard_blocks);
         }
         Ok(result)
+    }
+}
+
+impl Drop for StorageEngine {
+    fn drop(&mut self) {
+        // Signal the pre-eviction thread to stop
+        self.pre_evict_stop.store(true, Ordering::Relaxed);
+
+        // Wait for the thread to finish
+        if let Some(handle) = self.pre_evict_handle.take() {
+            debug!("Waiting for pre-eviction monitor thread to stop");
+            if let Err(e) = handle.join() {
+                error!("Failed to join pre-eviction monitor thread: {:?}", e);
+            }
+        }
     }
 }
 

--- a/pegaflow-server/src/lib.rs
+++ b/pegaflow-server/src/lib.rs
@@ -172,6 +172,23 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     );
 
     let pre_evict_config = if cli.pre_evict {
+        // Validate: target must be greater than threshold to ensure eviction frees memory
+        if cli.pre_evict_target <= cli.pre_evict_threshold {
+            return Err(format!(
+                "--pre-evict-target ({}) must be greater than --pre-evict-threshold ({})",
+                cli.pre_evict_target, cli.pre_evict_threshold
+            )
+            .into());
+        }
+        // Validate: target must not exceed pool capacity
+        if cli.pre_evict_target > cli.pool_size {
+            return Err(format!(
+                "--pre-evict-target ({}) must not exceed --pool-size ({})",
+                cli.pre_evict_target, cli.pool_size
+            )
+            .into());
+        }
+
         info!(
             "Pre-eviction enabled: threshold={:.2} GiB, target={:.2} GiB, interval={}ms",
             cli.pre_evict_threshold as f64 / (1024.0 * 1024.0 * 1024.0),


### PR DESCRIPTION


This commit introduces a new pre-eviction feature that proactively reclaims memory when free space drops below a configured threshold. Key changes include:
- PreEvictConfig struct with threshold/target settings and interval
- Background monitoring thread in StorageEngine
- Byte-based eviction tracking in Block/LayerBlock
- New CLI parameters for pre-eviction configuration
- Thread-safe memory reclamation methods

The implementation reduces allocation stalls by maintaining minimum free memory levels through proactive LRU eviction.