### PR TITLE
refactor(storage): Separate inflight (write) and cache (read) paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "page_size",
@@ -336,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools",
 ]
 
 [[package]]
@@ -408,6 +408,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b8688c7a5a250a5064e7022d790620cab8d5a3ab2ac1ea56511d8aff8bf02a"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -634,6 +648,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -647,7 +667,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -904,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -937,15 +957,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1326,6 +1337,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "cudarc",
+ "dashmap",
  "hashlink",
  "libc",
  "offset-allocator",
@@ -1532,7 +1544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -1554,7 +1566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { version = "1.0", features = ["v4"] }
 parking_lot = "0.12"
 clap = { version = "4.5", features = ["derive"] }
 crossbeam = "0.8"
+dashmap = "6.1"
 opentelemetry = { version = "0.31.0", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.31.0", features = [
   "trace",

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -13,6 +13,7 @@ rand.workspace = true
 shared_memory.workspace = true
 uuid.workspace = true
 crossbeam.workspace = true
+dashmap.workspace = true
 opentelemetry.workspace = true
 bytesize.workspace = true
 libc = "0.2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Overhauls the storage layer to a two-phase design for clearer concurrency and eviction boundaries.
> 
> - Introduces `InflightBlock` (mutable writes via `DashMap<BlockKey, Mutex<_>>`) and `SealedBlock` (immutable, cached in `LruCache`)
> - Replaces `insert_block` with `insert_slot` and `lookup_many` with `cache_lookup_many`; adds `cache_contains` and `inflight_has_slot`
> - Save path now skips when sealed in cache or slot exists inflight; auto-seals and migrates to cache when a block completes
> - Load path updated to use `cache_lookup_many` and borrow slots immutably (`get_slot(...)? .clone()`)
> - Eviction targets cache only; pre-eviction monitor updated to operate on sealed blocks
> - Adds `dashmap` dependency and wires it into `pegaflow-core`; minor Cargo.lock crate resolution cleanups (itertools/hashbrown)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0278ff5fd4e49a5450d18ec2bc25989f80e23861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->