### PR TITLE
feat(engine): add sealed block offload mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1360,7 @@ dependencies = [
 name = "pegaflow-core"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytesize",
  "criterion",
  "cudarc",
@@ -2615,6 +2629,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +295,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,28 +360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,15 +374,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -675,6 +664,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1140,6 +1135,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,14 +1349,17 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "criterion",
- "crossbeam",
  "cudarc",
  "dashmap",
  "hashlink",
+ "hex",
  "libc",
  "offset-allocator",
  "opentelemetry",
  "rand 0.9.2",
+ "redis",
+ "serde",
+ "serde_json",
  "shared_memory",
  "tokio",
  "tracing",
@@ -1389,6 +1406,7 @@ dependencies = [
  "prost",
  "pyo3",
  "pyo3-build-config",
+ "redis",
  "reqwest",
  "serde",
  "serde_json",
@@ -1757,6 +1775,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfe20977fe93830c0e9817a16fbf1ed1cfd8d4bba366087a1841d2c6033c251"
+dependencies = [
+ "arcstr",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2064,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sharded-slab"
@@ -2968,6 +3016,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ tonic-prost = "0.14"
 pyo3 = { version = "0.27" }
 pyo3-build-config = { version = "0.27", features = ["resolve-config"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+# Redis
+redis = { version = "1.0", features = ["tokio-comp"] }
+
 # Dev dependencies
 criterion = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ opentelemetry_sdk = { version = "0.31.0", features = [
   "rt-tokio-current-thread",
 ] }
 bytesize = "2.3.1"
+ahash = "0.8"
 
 # HTTP/Web
 axum = "0.8"

--- a/examples/bench_kv_cache.py
+++ b/examples/bench_kv_cache.py
@@ -103,10 +103,8 @@ class VLLMServer:
                 "--port",
                 str(self.port),
                 "--trust-remote-code",
-                "--data-parallel-size",
-                "1",
-                "--prefix-caching-hash-algo",
-                "sha256_cbor",
+                "--block-size",
+                "64",
             ]
         )
 

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 serde_json.workspace = true
 libc = "0.2"
 hex = "0.4"
+ahash.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/pegaflow-core/Cargo.toml
+++ b/pegaflow-core/Cargo.toml
@@ -12,11 +12,14 @@ tokio.workspace = true
 rand.workspace = true
 shared_memory.workspace = true
 uuid.workspace = true
-crossbeam.workspace = true
 dashmap.workspace = true
 opentelemetry.workspace = true
 bytesize.workspace = true
+redis.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 libc = "0.2"
+hex = "0.4"
 
 [dev-dependencies]
 criterion.workspace = true

--- a/pegaflow-core/src/cache.rs
+++ b/pegaflow-core/src/cache.rs
@@ -1,0 +1,209 @@
+use ahash::RandomState;
+use hashlink::LruCache;
+use std::hash::Hash;
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use crate::storage::{BlockKey, SealedBlock};
+
+const DEFAULT_BYTES_PER_VALUE: usize = 1024 * 1024; // heuristic: 1MB per block
+
+/// LRU cache with TinyLFU-based admission. Keeps API surface tiny to avoid
+/// bloating storage.rs.
+pub(crate) struct TinyLfuCache<K, V> {
+    lru: LruCache<K, V>,
+    freq: TinyLfu,
+}
+
+impl TinyLfuCache<BlockKey, ArcSealedBlock> {
+    pub fn new_unbounded(capacity_bytes: usize) -> Self {
+        let estimated_items = std::cmp::max(1, capacity_bytes / DEFAULT_BYTES_PER_VALUE);
+        Self {
+            lru: LruCache::new_unbounded(),
+            freq: TinyLfu::new(estimated_items),
+        }
+    }
+
+    pub fn contains_key(&self, key: &BlockKey) -> bool {
+        self.lru.contains_key(key)
+    }
+
+    /// Returns a cloned value and bumps frequency on hit.
+    pub fn get(&mut self, key: &BlockKey) -> Option<ArcSealedBlock> {
+        let hit = self.lru.get(key).cloned();
+        if hit.is_some() {
+            self.freq.incr(key);
+        }
+        hit
+    }
+
+    /// Insert with TinyLFU admission. If the candidate is colder than the
+    /// current LRU victim it is dropped. Returns true if inserted.
+    pub fn insert(&mut self, key: BlockKey, value: ArcSealedBlock) -> bool {
+        // Always record the access so future attempts have a chance.
+        self.freq.incr(&key);
+
+        // Update existing entry eagerly.
+        if self.lru.contains_key(&key) {
+            self.lru.insert(key, value);
+            return true;
+        }
+
+        let candidate_freq = self.freq.get(&key);
+        if let Some((victim_key, _)) = self.lru.iter().next() {
+            let victim_freq = self.freq.get(victim_key);
+            if candidate_freq < victim_freq {
+                return false;
+            }
+        }
+
+        self.lru.insert(key, value);
+        true
+    }
+
+    pub fn remove_lru(&mut self) -> Option<(BlockKey, ArcSealedBlock)> {
+        self.lru.remove_lru()
+    }
+}
+
+pub(crate) type ArcSealedBlock = Arc<SealedBlock>;
+
+// Bare-minimum TinyLFU with CM-Sketch; no doorkeeper.
+struct Estimator {
+    estimator: Box<[(Box<[AtomicU8]>, RandomState)]>,
+}
+
+impl Estimator {
+    fn optimal_paras(items: usize) -> (usize, usize) {
+        use std::cmp::max;
+        // derived from https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch
+        // width = ceil(e / ε)
+        // depth = ceil(ln(1 − δ) / ln(1 / 2))
+        let error_range = 1.0 / (items as f64);
+        let failure_probability = 1.0 / (items as f64);
+        (
+            max((std::f64::consts::E / error_range).ceil() as usize, 16),
+            max((failure_probability.ln() / 0.5f64.ln()).ceil() as usize, 2),
+        )
+    }
+
+    fn optimal(items: usize) -> Self {
+        let (slots, hashes) = Self::optimal_paras(items);
+        Self::new(hashes, slots, RandomState::new)
+    }
+
+    fn compact(items: usize) -> Self {
+        let (slots, hashes) = Self::optimal_paras(items / 100);
+        Self::new(hashes, slots, RandomState::new)
+    }
+
+    /// Create a new `Estimator` with the given amount of hashes and columns (slots) using
+    /// the given random source.
+    fn new(hashes: usize, slots: usize, random: impl Fn() -> RandomState) -> Self {
+        let mut estimator = Vec::with_capacity(hashes);
+        for _ in 0..hashes {
+            let mut slot = Vec::with_capacity(slots);
+            for _ in 0..slots {
+                slot.push(AtomicU8::new(0));
+            }
+            estimator.push((slot.into_boxed_slice(), random()));
+        }
+
+        Estimator {
+            estimator: estimator.into_boxed_slice(),
+        }
+    }
+
+    fn incr<T: Hash>(&self, key: T) -> u8 {
+        let mut min = u8::MAX;
+        for (slot, hasher) in self.estimator.iter() {
+            let hash = hasher.hash_one(&key) as usize;
+            let counter = &slot[hash % slot.len()];
+            let (_current, new) = incr_no_overflow(counter);
+            min = std::cmp::min(min, new);
+        }
+        min
+    }
+
+    /// Get the estimated frequency of `key`.
+    fn get<T: Hash>(&self, key: T) -> u8 {
+        let mut min = u8::MAX;
+        for (slot, hasher) in self.estimator.iter() {
+            let hash = hasher.hash_one(&key) as usize;
+            let counter = &slot[hash % slot.len()];
+            let current = counter.load(Ordering::Relaxed);
+            min = std::cmp::min(min, current);
+        }
+        min
+    }
+
+    /// right shift all values inside this `Estimator`.
+    fn age(&self, shift: u8) {
+        for (slot, _) in self.estimator.iter() {
+            for counter in slot.iter() {
+                let c = counter.load(Ordering::Relaxed);
+                counter.store(c >> shift, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+fn incr_no_overflow(var: &AtomicU8) -> (u8, u8) {
+    loop {
+        let current = var.load(Ordering::Relaxed);
+        if current == u8::MAX {
+            return (current, current);
+        }
+        let new = if current == u8::MAX - 1 {
+            u8::MAX
+        } else {
+            current + 1
+        };
+        if let Err(new) = var.compare_exchange(current, new, Ordering::Acquire, Ordering::Relaxed) {
+            if new == u8::MAX {
+                return (current, new);
+            }
+        } else {
+            return (current, new);
+        }
+    }
+}
+
+pub(crate) struct TinyLfu {
+    estimator: Estimator,
+    window_counter: AtomicUsize,
+    window_limit: usize,
+}
+
+impl TinyLfu {
+    pub fn get<T: Hash>(&self, key: T) -> u8 {
+        self.estimator.get(key)
+    }
+
+    pub fn incr<T: Hash>(&self, key: T) -> u8 {
+        let window_size = self.window_counter.fetch_add(1, Ordering::Relaxed);
+        if window_size == self.window_limit || window_size > self.window_limit * 2 {
+            self.window_counter.store(0, Ordering::Relaxed);
+            self.estimator.age(1); // right shift 1 bit
+        }
+        self.estimator.incr(key)
+    }
+
+    // Because we use 8-bit counters, window size can be 256 * the cache size.
+    pub fn new(cache_size: usize) -> Self {
+        Self {
+            estimator: Estimator::optimal(cache_size),
+            window_counter: Default::default(),
+            window_limit: cache_size * 8,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_compact(cache_size: usize) -> Self {
+        Self {
+            estimator: Estimator::compact(cache_size),
+            window_counter: Default::default(),
+            window_limit: cache_size * 8,
+        }
+    }
+}

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -9,7 +9,11 @@ pub mod sync_state;
 mod transfer;
 
 pub use pinned_pool::PinnedAllocation;
-pub use seal_offload::spawn_seal_offload_task;
+pub use seal_offload::{
+    batch_get_block_meta, get_block_meta, prefetch_blocks_from_dfs, spawn_dfs_offload_task,
+    spawn_seal_offload_task, BlockMeta, DfsOffloadConfig, PrefetchStatus, PrefetchTracker,
+    SlotMeta,
+};
 pub use storage::{PreEvictConfig, SealNotification};
 pub use sync_state::{LoadState, LoadStateError};
 
@@ -89,7 +93,7 @@ pub struct PegaEngine {
     /// Manages instances and their GPU contexts
     instances: RwLock<HashMap<String, Arc<InstanceContext>>>,
     /// Storage engine responsible for pinned allocations + block cache
-    storage: StorageEngine,
+    storage: Arc<StorageEngine>,
 }
 
 #[derive(Debug, Clone)]
@@ -290,13 +294,13 @@ impl PegaEngine {
         pool_size: usize,
         use_hugepages: bool,
         pre_evict_config: storage::PreEvictConfig,
-    ) -> (Self, crossbeam::channel::Receiver<SealNotification>) {
+    ) -> (Self, tokio::sync::mpsc::UnboundedReceiver<SealNotification>) {
         let (storage, seal_notify_rx) =
             StorageEngine::new_with_config(pool_size, use_hugepages, pre_evict_config);
         (
             PegaEngine {
                 instances: RwLock::new(HashMap::new()),
-                storage,
+                storage: Arc::new(storage),
             },
             seal_notify_rx,
         )
@@ -830,6 +834,109 @@ impl PegaEngine {
         );
 
         Ok(hit_count)
+    }
+
+    /// Count prefix hit blocks with async DFS prefetch support.
+    ///
+    /// Returns:
+    /// - `Ready(n)`: n blocks are in local cache, ready for immediate load
+    /// - `Prefetching { ready, loading }`: ready blocks in cache, loading blocks being fetched
+    /// - `PartialMiss { ready, missing }`: some blocks don't exist in DFS either
+    ///
+    /// When a cache miss is detected but Redis has metadata, this method automatically
+    /// starts a background prefetch from DFS. The caller should retry after a short delay.
+    #[instrument(
+        level = "debug",
+        skip(self, block_hashes, redis_conn, tracker),
+        err,
+        fields(instance=%instance_id, requested = %block_hashes.len())
+    )]
+    pub async fn count_prefix_hit_blocks_async(
+        &self,
+        instance_id: &str,
+        block_hashes: &[Vec<u8>],
+        redis_conn: &mut redis::aio::MultiplexedConnection,
+        tracker: &Arc<seal_offload::PrefetchTracker>,
+        dfs_root: &std::path::Path,
+    ) -> Result<seal_offload::PrefetchStatus, EngineError> {
+        use seal_offload::{batch_get_block_meta, prefetch_blocks_from_dfs, PrefetchStatus};
+
+        let instance = self.get_instance(instance_id)?;
+        let namespace = &instance.namespace;
+
+        let mut ready = 0usize;
+        let mut loading = 0usize;
+        let mut first_miss_idx = None;
+
+        // Count local cache hits and check pending prefetches
+        for (idx, block_hash) in block_hashes.iter().enumerate() {
+            if self.storage.cache_contains(namespace, block_hash) {
+                ready += 1;
+            } else if tracker.is_pending(namespace, block_hash) {
+                loading += 1;
+            } else {
+                // First block not in cache and not pending
+                first_miss_idx = Some(idx);
+                break;
+            }
+        }
+
+        // If all blocks are in cache or loading, return current status
+        if first_miss_idx.is_none() {
+            if loading > 0 {
+                return Ok(PrefetchStatus::Prefetching { ready, loading });
+            } else {
+                return Ok(PrefetchStatus::Ready(ready));
+            }
+        }
+
+        let miss_idx = first_miss_idx.unwrap();
+
+        // Check if prefetch is at capacity
+        if tracker.available_permits() == 0 {
+            debug!("Prefetch at capacity, treating as partial miss");
+            return Ok(PrefetchStatus::PartialMiss {
+                ready,
+                missing: block_hashes.len() - ready - loading,
+            });
+        }
+
+        // Query Redis for the first missing block to check if it exists in DFS
+        let miss_hashes = vec![block_hashes[miss_idx].clone()];
+        let metas = batch_get_block_meta(redis_conn, namespace, &miss_hashes)
+            .await
+            .map_err(|e| EngineError::Storage(format!("Redis query failed: {}", e)))?;
+
+        if metas[0].is_none() {
+            // Block doesn't exist in DFS either
+            debug!(
+                miss_idx,
+                "Block not found in Redis, treating as partial miss"
+            );
+            return Ok(PrefetchStatus::PartialMiss {
+                ready: ready + loading,
+                missing: block_hashes.len() - ready - loading,
+            });
+        }
+
+        // Block exists in Redis, start prefetch for remaining blocks
+        let to_prefetch: Vec<Vec<u8>> = block_hashes[miss_idx..].to_vec();
+        let prefetch_count = to_prefetch.len();
+
+        // Spawn prefetch task (fire and forget)
+        prefetch_blocks_from_dfs(
+            Arc::clone(&self.storage),
+            redis_conn.clone(),
+            Arc::clone(tracker),
+            dfs_root.to_path_buf(),
+            namespace.to_string(),
+            to_prefetch,
+        );
+
+        Ok(PrefetchStatus::Prefetching {
+            ready,
+            loading: loading + prefetch_count,
+        })
     }
 
     /// Batch load KV blocks for multiple layers asynchronously.

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod allocator;
+mod cache;
 pub mod gpu_worker;
 mod metrics;
 pub mod pinned_mem;

--- a/pegaflow-core/src/lib.rs
+++ b/pegaflow-core/src/lib.rs
@@ -15,7 +15,7 @@ pub use seal_offload::{
     spawn_seal_offload_task, BlockMeta, DfsOffloadConfig, PrefetchStatus, PrefetchTracker,
     SlotMeta,
 };
-pub use storage::{PreEvictConfig, SealNotification};
+pub use storage::{PreEvictConfig, SealNotification, StorageConfig};
 pub use sync_state::{LoadState, LoadStateError};
 
 // ============================================================================
@@ -273,7 +273,7 @@ impl PegaEngine {
         let (engine, _rx) = Self::new_with_config(
             DEFAULT_PINNED_POOL_BYTES,
             false,
-            storage::PreEvictConfig::default(),
+            storage::StorageConfig::default(),
         );
         engine
     }
@@ -283,21 +283,21 @@ impl PegaEngine {
     /// If `use_hugepages` is true, uses 2MB huge pages (requires system config).
     pub fn new_with_pool_size(pool_size: usize, use_hugepages: bool) -> Self {
         let (engine, _rx) =
-            Self::new_with_config(pool_size, use_hugepages, storage::PreEvictConfig::default());
+            Self::new_with_config(pool_size, use_hugepages, storage::StorageConfig::default());
         engine
     }
 
-    /// Create a new PegaEngine instance with custom pool size and pre-eviction config
+    /// Create a new PegaEngine instance with custom pool size and storage config
     ///
     /// If `use_hugepages` is true, uses 2MB huge pages (requires system config).
     /// Returns (engine, seal_notify_rx) - pass receiver to `spawn_seal_offload_task` for SSD offload.
     pub fn new_with_config(
         pool_size: usize,
         use_hugepages: bool,
-        pre_evict_config: storage::PreEvictConfig,
+        storage_config: impl Into<storage::StorageConfig>,
     ) -> (Self, tokio::sync::mpsc::UnboundedReceiver<SealNotification>) {
         let (storage, seal_notify_rx) =
-            StorageEngine::new_with_config(pool_size, use_hugepages, pre_evict_config);
+            StorageEngine::new_with_config(pool_size, use_hugepages, storage_config);
         (
             PegaEngine {
                 instances: RwLock::new(HashMap::new()),

--- a/pegaflow-core/src/metrics.rs
+++ b/pegaflow-core/src/metrics.rs
@@ -11,6 +11,7 @@ pub(crate) struct CoreMetrics {
     pub cache_block_hits: Counter<u64>,
     pub cache_block_misses: Counter<u64>,
     pub cache_block_insertions: Counter<u64>,
+    pub cache_block_admission_rejections: Counter<u64>,
     pub cache_block_evictions: Counter<u64>,
 
     pub save_bytes: Counter<u64>,
@@ -52,6 +53,10 @@ pub(crate) fn core_metrics() -> &'static CoreMetrics {
             cache_block_insertions: meter
                 .u64_counter("pegaflow_cache_block_insertions_total")
                 .with_description("New blocks inserted into cache")
+                .build(),
+            cache_block_admission_rejections: meter
+                .u64_counter("pegaflow_cache_block_admission_rejections_total")
+                .with_description("Blocks rejected by cache admission policy")
                 .build(),
             cache_block_evictions: meter
                 .u64_counter("pegaflow_cache_block_evictions_total")

--- a/pegaflow-core/src/seal_offload.rs
+++ b/pegaflow-core/src/seal_offload.rs
@@ -1,0 +1,51 @@
+// ============================================================================
+// Seal Offload: Background task for write-through to SSD
+//
+// Receives notifications when blocks are sealed and offloads them to SSD.
+// Uses Weak<SealedBlock> to avoid holding blocks in memory if evicted.
+// ============================================================================
+
+use bytesize::ByteSize;
+use crossbeam::channel::Receiver;
+use tracing::{debug, info};
+
+use crate::storage::SealNotification;
+
+/// Spawn a tokio task that consumes seal notifications.
+/// Currently just logs for verification; will be extended to write to SSD.
+pub fn spawn_seal_offload_task(rx: Receiver<SealNotification>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        info!("Seal offload task started");
+        loop {
+            // Use recv() in a blocking manner via spawn_blocking to avoid busy-wait
+            let notification = {
+                let rx = rx.clone();
+                tokio::task::spawn_blocking(move || rx.recv())
+                    .await
+                    .expect("spawn_blocking panicked")
+            };
+
+            match notification {
+                Ok((key, weak_block)) => {
+                    if let Some(block) = weak_block.upgrade() {
+                        debug!(
+                            namespace = %key.namespace,
+                            hash_len = key.hash.len(),
+                            footprint = %ByteSize(block.memory_footprint()),
+                            "Sealed block received for offload"
+                        );
+                    } else {
+                        debug!(
+                            namespace = %key.namespace,
+                            "Sealed block already evicted before offload"
+                        );
+                    }
+                }
+                Err(_) => {
+                    info!("Seal notification channel closed, stopping offload task");
+                    break;
+                }
+            }
+        }
+    })
+}

--- a/pegaflow-core/src/seal_offload.rs
+++ b/pegaflow-core/src/seal_offload.rs
@@ -1,51 +1,909 @@
 // ============================================================================
-// Seal Offload: Background task for write-through to SSD
+// DFS Offload: Background write-through to distributed filesystem
 //
-// Receives notifications when blocks are sealed and offloads them to SSD.
-// Uses Weak<SealedBlock> to avoid holding blocks in memory if evicted.
+// When blocks are sealed, this module offloads them to DFS for persistence.
+// Uses Weak<SealedBlock> to avoid holding blocks in memory if evicted early.
+//
+// Data flow:
+//   SealNotification (batch) → group by namespace
+//                            → write_packed_file() per namespace
+//                            → update Redis metadata
+//
+// File packing:
+//   Multiple blocks are packed into one file: {namespace}/{uuid}.bin
+//   Each block's offset is recorded in BlockMeta.offset
+//
+// Redis schema:
+//   pega:block:{ns}:{hash}  → BlockMeta JSON (file, offset, slots)
+//   pega:file:{ns}:{uuid}   → FileMeta JSON (blocks list, size)
+//   pega:files              → ZSET of ns:uuid scored by timestamp (LRU)
+//   pega:usage              → total bytes counter for quota
 // ============================================================================
 
 use bytesize::ByteSize;
-use crossbeam::channel::Receiver;
-use tracing::{debug, info};
+use dashmap::DashMap;
+use redis::aio::MultiplexedConnection;
+use redis::{AsyncCommands, Script};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::fs;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::time::Instant;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
-use crate::storage::SealNotification;
+use crate::storage::{BlockKey, LayerBlock, SealNotification, SealedBlock, StorageEngine};
 
-/// Spawn a tokio task that consumes seal notifications.
-/// Currently just logs for verification; will be extended to write to SSD.
-pub fn spawn_seal_offload_task(rx: Receiver<SealNotification>) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        info!("Seal offload task started");
-        loop {
-            // Use recv() in a blocking manner via spawn_blocking to avoid busy-wait
-            let notification = {
-                let rx = rx.clone();
-                tokio::task::spawn_blocking(move || rx.recv())
-                    .await
-                    .expect("spawn_blocking panicked")
-            };
+// ============================================================================
+// Configuration & Types
+// ============================================================================
 
-            match notification {
-                Ok((key, weak_block)) => {
-                    if let Some(block) = weak_block.upgrade() {
-                        debug!(
-                            namespace = %key.namespace,
-                            hash_len = key.hash.len(),
-                            footprint = %ByteSize(block.memory_footprint()),
-                            "Sealed block received for offload"
-                        );
-                    } else {
-                        debug!(
-                            namespace = %key.namespace,
-                            "Sealed block already evicted before offload"
-                        );
-                    }
-                }
-                Err(_) => {
-                    info!("Seal notification channel closed, stopping offload task");
-                    break;
+/// Configuration for DFS offload
+#[derive(Debug, Clone)]
+pub struct DfsOffloadConfig {
+    /// Root directory on DFS (e.g., "/mnt/dfs/pega")
+    pub dfs_root: PathBuf,
+    /// Hard limit in bytes (triggers eviction when exceeded)
+    pub quota_bytes: u64,
+    /// Quota scan interval in milliseconds
+    pub scan_interval_ms: u64,
+    /// Max blocks per packed file
+    pub max_pack_size: usize,
+    /// Batch size for eviction queries (how many files to fetch per ZRANGE)
+    pub evict_batch_size: usize,
+}
+
+impl Default for DfsOffloadConfig {
+    fn default() -> Self {
+        Self {
+            dfs_root: PathBuf::from("/mnt/dfs/pega"),
+            quota_bytes: 100 * 1024 * 1024 * 1024, // 100GB
+            scan_interval_ms: 100,
+            max_pack_size: 64,
+            evict_batch_size: 100,
+        }
+    }
+}
+
+/// Per-slot metadata (one slot = one layer's KV cache)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlotMeta {
+    /// K and V stored separately (split) or together (contiguous)
+    pub is_split: bool,
+    /// Total size in bytes (K + V combined)
+    pub size: u64,
+}
+
+/// Block metadata stored in Redis
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockMeta {
+    /// File name ({uuid}.bin)
+    pub file: String,
+    /// Offset within file
+    pub offset: u64,
+    /// Per-slot layout info
+    pub slots: Vec<SlotMeta>,
+    /// Total slots (layers * tp_size) for rebuilding SealedBlock
+    pub total_slots: usize,
+}
+
+impl BlockMeta {
+    pub fn total_size(&self) -> u64 {
+        self.slots.iter().map(|s| s.size).sum()
+    }
+}
+
+/// File metadata in Redis (tracks blocks referencing this file)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FileMeta {
+    blocks: Vec<String>, // block hashes (hex)
+    size: u64,
+}
+
+/// A block ready for writing (after upgrading Weak)
+struct ReadyBlock {
+    key: BlockKey,
+    block: Arc<SealedBlock>,
+}
+
+// ============================================================================
+// Redis Keys
+// ============================================================================
+
+fn redis_block_key(namespace: &str, hash: &[u8]) -> String {
+    format!("pega:block:{}:{}", namespace, hex::encode(hash))
+}
+
+fn redis_file_key(namespace: &str, uuid: &Uuid) -> String {
+    format!("pega:file:{}:{}", namespace, uuid)
+}
+
+fn redis_files_zset_key() -> &'static str {
+    "pega:files"
+}
+
+fn redis_usage_key() -> &'static str {
+    "pega:usage"
+}
+
+// ============================================================================
+// Lua Scripts
+// ============================================================================
+
+/// Atomic batch write: SET multiple blocks, SET file meta, ZADD files, INCRBY usage
+/// KEYS: [file_key, files_zset, usage_key]
+/// ARGV: [file_meta_json, zset_member, file_size, timestamp, block_key1, block_meta1, hash1, ...]
+const LUA_WRITE_BATCH: &str = r#"
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('ZADD', KEYS[2], ARGV[4], ARGV[2])
+redis.call('INCRBY', KEYS[3], tonumber(ARGV[3]))
+local i = 5
+while i <= #ARGV do
+    redis.call('SET', ARGV[i], ARGV[i+1])
+    i = i + 3
+end
+return 1
+"#;
+
+/// Atomic file delete: DEL blocks, DEL file, ZREM files, DECRBY usage
+const LUA_DELETE_FILE: &str = r#"
+for i = 3, #ARGV do
+    redis.call('DEL', ARGV[i])
+end
+redis.call('DEL', KEYS[1])
+redis.call('ZREM', KEYS[2], ARGV[1])
+redis.call('DECRBY', KEYS[3], tonumber(ARGV[2]))
+return #ARGV - 2
+"#;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Spawn DFS offload and quota scan tasks.
+///
+/// Returns JoinHandles for (offload_task, quota_task).
+pub async fn spawn_dfs_offload_task(
+    rx: UnboundedReceiver<SealNotification>,
+    redis_url: &str,
+    config: DfsOffloadConfig,
+) -> Result<(tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>), redis::RedisError> {
+    let client = redis::Client::open(redis_url)?;
+    let conn = client.get_multiplexed_async_connection().await?;
+    let quota_conn = client.get_multiplexed_async_connection().await?;
+
+    info!(
+        redis_url = %redis_url,
+        dfs_root = %config.dfs_root.display(),
+        quota = %ByteSize(config.quota_bytes),
+        max_pack_size = config.max_pack_size,
+        "DFS offload started"
+    );
+
+    let quota_config = config.clone();
+    let offload_handle = tokio::spawn(offload_loop(rx, conn, config));
+    let quota_handle = tokio::spawn(quota_loop(quota_conn, quota_config));
+
+    Ok((offload_handle, quota_handle))
+}
+
+/// Read block metadata from Redis.
+pub async fn get_block_meta(
+    conn: &mut MultiplexedConnection,
+    namespace: &str,
+    hash: &[u8],
+) -> Result<Option<BlockMeta>, redis::RedisError> {
+    let key = redis_block_key(namespace, hash);
+    let json: Option<String> = conn.get(&key).await?;
+
+    Ok(json.and_then(|j| serde_json::from_str(&j).ok()))
+}
+
+/// Batch lookup block metadata from Redis.
+pub async fn batch_get_block_meta(
+    conn: &mut MultiplexedConnection,
+    namespace: &str,
+    hashes: &[Vec<u8>],
+) -> Result<Vec<Option<BlockMeta>>, redis::RedisError> {
+    if hashes.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let keys: Vec<String> = hashes
+        .iter()
+        .map(|h| redis_block_key(namespace, h))
+        .collect();
+
+    let values: Vec<Option<String>> = conn.mget(&keys).await?;
+
+    Ok(values
+        .into_iter()
+        .map(|opt| opt.and_then(|j| serde_json::from_str(&j).ok()))
+        .collect())
+}
+
+// Legacy alias
+pub use spawn_dfs_offload_task as spawn_seal_offload_task;
+
+// ============================================================================
+// Offload Loop (batch receive + pack by namespace)
+// ============================================================================
+
+async fn offload_loop(
+    mut rx: UnboundedReceiver<SealNotification>,
+    mut conn: MultiplexedConnection,
+    config: DfsOffloadConfig,
+) {
+    let write_script = Script::new(LUA_WRITE_BATCH);
+
+    loop {
+        // Wait for first notification
+        let Some(first) = rx.recv().await else {
+            break;
+        };
+
+        // Collect batch (non-blocking)
+        let mut notifications = vec![first];
+        while notifications.len() < config.max_pack_size {
+            match rx.try_recv() {
+                Ok(n) => notifications.push(n),
+                Err(_) => break,
+            }
+        }
+
+        // Upgrade Weak refs, filter evicted blocks
+        let ready: Vec<ReadyBlock> = notifications
+            .into_iter()
+            .filter_map(|(key, weak)| weak.upgrade().map(|block| ReadyBlock { key, block }))
+            .collect();
+
+        if ready.is_empty() {
+            continue;
+        }
+
+        // Group by namespace
+        let mut by_namespace: HashMap<String, Vec<ReadyBlock>> = HashMap::new();
+        for rb in ready {
+            by_namespace
+                .entry(rb.key.namespace.clone())
+                .or_default()
+                .push(rb);
+        }
+
+        // Write each namespace's blocks to a packed file
+        for (namespace, blocks) in by_namespace {
+            if let Err(e) = write_and_register(
+                &mut conn,
+                &write_script,
+                &namespace,
+                blocks,
+                &config.dfs_root,
+            )
+            .await
+            {
+                error!(namespace = %namespace, "Failed to write packed file: {}", e);
+            }
+        }
+    }
+
+    info!("Offload loop stopped");
+}
+
+/// Write blocks to a packed file and register in Redis.
+async fn write_and_register(
+    conn: &mut MultiplexedConnection,
+    script: &Script,
+    namespace: &str,
+    blocks: Vec<ReadyBlock>,
+    dfs_root: &Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let block_count = blocks.len();
+    let total_size: u64 = blocks.iter().map(|b| b.block.memory_footprint()).sum();
+
+    debug!(
+        namespace = %namespace,
+        blocks = block_count,
+        size = %ByteSize(total_size),
+        "Writing packed file"
+    );
+
+    // Write to DFS
+    let (file_uuid, block_metas) = write_packed_file(namespace, &blocks, dfs_root).await?;
+
+    // Prepare Redis update
+    let file_name = format!("{}.bin", file_uuid);
+    let file_key = redis_file_key(namespace, &file_uuid);
+    let zset_member = format!("{}:{}", namespace, file_uuid);
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+
+    // Build FileMeta
+    let file_meta = FileMeta {
+        blocks: blocks.iter().map(|b| hex::encode(&b.key.hash)).collect(),
+        size: total_size,
+    };
+    let file_meta_json = serde_json::to_string(&file_meta)?;
+
+    // Build script args
+    let mut invocation = script.key(&file_key);
+    invocation
+        .key(redis_files_zset_key())
+        .key(redis_usage_key())
+        .arg(&file_meta_json)
+        .arg(&zset_member)
+        .arg(total_size)
+        .arg(now_ms);
+
+    // Add each block's metadata
+    for (rb, meta) in blocks.iter().zip(block_metas.iter()) {
+        let block_key = redis_block_key(namespace, &rb.key.hash);
+        let meta_json = serde_json::to_string(meta)?;
+        invocation
+            .arg(&block_key)
+            .arg(&meta_json)
+            .arg(hex::encode(&rb.key.hash));
+    }
+
+    // Execute
+    if let Err(e) = invocation.invoke_async::<i32>(conn).await {
+        // Cleanup orphaned file
+        let file_path = dfs_root.join(namespace).join(&file_name);
+        let _ = fs::remove_file(&file_path).await;
+        return Err(e.into());
+    }
+
+    info!(
+        namespace = %namespace,
+        file = %file_name,
+        blocks = block_count,
+        size = %ByteSize(total_size),
+        "Packed file written"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Packed File Write (zero-copy from pinned memory)
+// ============================================================================
+
+/// Write multiple blocks to a single packed file.
+/// Returns (file_uuid, Vec<BlockMeta>) with each block's offset.
+#[tracing::instrument(level = "info", skip(blocks), fields(blocks = blocks.len()))]
+async fn write_packed_file(
+    namespace: &str,
+    blocks: &[ReadyBlock],
+    dfs_root: &Path,
+) -> std::io::Result<(Uuid, Vec<BlockMeta>)> {
+    let dir = dfs_root.join(namespace);
+    fs::create_dir_all(&dir).await?;
+
+    let uuid = Uuid::new_v4();
+    let file_name = format!("{}.bin", uuid);
+    let file_path = dir.join(&file_name);
+
+    // Get total_slots from first block (all blocks in a namespace have same topology)
+    let total_slots = blocks.first().map(|b| b.block.slots().len()).unwrap_or(0);
+
+    // Collect metadata for each block (computed before write)
+    let mut block_metas: Vec<BlockMeta> = Vec::with_capacity(blocks.len());
+    let mut current_offset = 0u64;
+
+    for rb in blocks {
+        let slots = rb.block.slots();
+        let slot_metas: Vec<SlotMeta> = slots
+            .iter()
+            .map(|s| SlotMeta {
+                is_split: s.v_ptr().is_some(),
+                size: s.size() as u64,
+            })
+            .collect();
+        let block_size: u64 = slot_metas.iter().map(|s| s.size).sum();
+
+        block_metas.push(BlockMeta {
+            file: file_name.clone(),
+            offset: current_offset,
+            slots: slot_metas,
+            total_slots,
+        });
+
+        current_offset += block_size;
+    }
+
+    // Clone Arcs for the blocking task
+    let block_arcs: Vec<Arc<SealedBlock>> = blocks.iter().map(|rb| Arc::clone(&rb.block)).collect();
+
+    // Write directly to target file — no rename needed since Redis index
+    // is the entry point; no reader can discover this UUID before Redis write
+    tokio::task::spawn_blocking(move || {
+        use std::io::Write;
+
+        let mut file = std::fs::File::create(&file_path)?;
+
+        for block in &block_arcs {
+            for slot in block.slots().iter() {
+                let size = slot.size();
+                if let Some(v_ptr) = slot.v_ptr() {
+                    let half = size / 2;
+                    file.write_all(unsafe { std::slice::from_raw_parts(slot.k_ptr(), half) })?;
+                    file.write_all(unsafe { std::slice::from_raw_parts(v_ptr, half) })?;
+                } else {
+                    file.write_all(unsafe { std::slice::from_raw_parts(slot.k_ptr(), size) })?;
                 }
             }
         }
+
+        file.sync_all()
     })
+    .await
+    .map_err(std::io::Error::other)??;
+
+    Ok((uuid, block_metas))
+}
+
+// ============================================================================
+// Quota Management & Eviction
+// ============================================================================
+
+async fn quota_loop(mut conn: MultiplexedConnection, config: DfsOffloadConfig) {
+    let interval = Duration::from_millis(config.scan_interval_ms);
+
+    loop {
+        tokio::time::sleep(interval).await;
+
+        if let Err(e) = check_quota(&mut conn, &config).await {
+            error!("Quota check failed: {}", e);
+        }
+    }
+}
+
+async fn check_quota(
+    conn: &mut MultiplexedConnection,
+    config: &DfsOffloadConfig,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let usage: i64 = conn.get(redis_usage_key()).await.unwrap_or(0);
+    let usage = usage.max(0) as u64;
+
+    if usage <= config.quota_bytes {
+        return Ok(());
+    }
+
+    let to_free = usage.saturating_sub(config.quota_bytes);
+    info!(
+        usage = %ByteSize(usage),
+        quota = %ByteSize(config.quota_bytes),
+        to_free = %ByteSize(to_free),
+        "Over quota, evicting"
+    );
+
+    evict_oldest(conn, config, to_free).await?;
+    Ok(())
+}
+
+#[tracing::instrument(level = "info", skip(conn, config), fields(target = %ByteSize(target)))]
+async fn evict_oldest(
+    conn: &mut MultiplexedConnection,
+    config: &DfsOffloadConfig,
+    target: u64,
+) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+    let start = Instant::now();
+    let delete_script = Script::new(LUA_DELETE_FILE);
+    let mut freed = 0u64;
+    // ZRANGE is inclusive [0, end], so fetch evict_batch_size items
+    let zrange_end = (config.evict_batch_size.saturating_sub(1)) as isize;
+
+    while freed < target {
+        let oldest: Vec<String> = conn.zrange(redis_files_zset_key(), 0, zrange_end).await?;
+        if oldest.is_empty() {
+            break;
+        }
+
+        for member in oldest {
+            if freed >= target {
+                break;
+            }
+
+            let Some((namespace, uuid)) = parse_zset_member(&member) else {
+                error!(member = %member, "Corrupt ZSET member: failed to parse namespace:uuid, removing");
+                let _: Result<(), _> = conn.zrem(redis_files_zset_key(), &member).await;
+                continue;
+            };
+
+            let file_key = redis_file_key(&namespace, &uuid);
+            let Some(meta_json): Option<String> = conn.get(&file_key).await.ok().flatten() else {
+                error!(member = %member, "Orphaned ZSET member: file metadata missing, removing");
+                let _: Result<(), _> = conn.zrem(redis_files_zset_key(), &member).await;
+                continue;
+            };
+
+            let Ok(meta) = serde_json::from_str::<FileMeta>(&meta_json) else {
+                error!(member = %member, meta = %meta_json, "Corrupt file metadata: JSON parse failed, removing");
+                let _: Result<(), _> = conn.zrem(redis_files_zset_key(), &member).await;
+                let _: Result<(), _> = conn.del::<_, ()>(&file_key).await;
+                continue;
+            };
+
+            let block_keys: Vec<String> = meta
+                .blocks
+                .iter()
+                .filter_map(|h| hex::decode(h).ok())
+                .map(|h| redis_block_key(&namespace, &h))
+                .collect();
+
+            // Delete file from DFS
+            let file_path = config
+                .dfs_root
+                .join(&namespace)
+                .join(format!("{}.bin", uuid));
+            let _ = fs::remove_file(&file_path).await;
+
+            // Delete Redis keys atomically
+            let mut inv = delete_script.key(&file_key);
+            inv.key(redis_files_zset_key())
+                .key(redis_usage_key())
+                .arg(&member)
+                .arg(meta.size);
+            for k in &block_keys {
+                inv.arg(k);
+            }
+            let _: Result<i32, _> = inv.invoke_async(conn).await;
+
+            freed += meta.size;
+            info!(file = %uuid, blocks = block_keys.len(), freed = %ByteSize(freed), "Evicted");
+        }
+    }
+
+    // Cleanup empty namespace dirs
+    if let Ok(mut entries) = fs::read_dir(&config.dfs_root).await {
+        while let Ok(Some(e)) = entries.next_entry().await {
+            let _ = fs::remove_dir(e.path()).await;
+        }
+    }
+
+    info!(freed = %ByteSize(freed), elapsed = ?start.elapsed(), "Eviction complete");
+    Ok(freed)
+}
+
+fn parse_zset_member(member: &str) -> Option<(String, Uuid)> {
+    let (ns, uuid_str) = member.rsplit_once(':')?;
+    Some((ns.to_string(), Uuid::parse_str(uuid_str).ok()?))
+}
+
+// ============================================================================
+// Prefetch: Read from DFS into cache
+// ============================================================================
+
+/// Result of checking prefix hits with prefetch support
+#[derive(Debug, Clone)]
+pub enum PrefetchStatus {
+    /// All requested blocks are in local cache
+    Ready(usize),
+    /// Some blocks are being prefetched from DFS
+    Prefetching {
+        /// Blocks already in cache
+        ready: usize,
+        /// Blocks currently being loaded from DFS
+        loading: usize,
+    },
+    /// Some blocks don't exist in DFS either
+    PartialMiss {
+        /// Blocks available (in cache or will be loaded)
+        ready: usize,
+        /// Blocks not found anywhere
+        missing: usize,
+    },
+}
+
+/// Tracks in-flight prefetch tasks. Thread-safe.
+pub struct PrefetchTracker {
+    /// Currently prefetching block keys
+    pending: DashMap<BlockKey, ()>,
+    /// Semaphore to limit concurrent prefetch tasks
+    semaphore: Arc<tokio::sync::Semaphore>,
+    /// Maximum concurrent prefetch tasks
+    max_concurrent: usize,
+}
+
+impl PrefetchTracker {
+    pub fn new(max_concurrent: usize) -> Self {
+        Self {
+            pending: DashMap::new(),
+            semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrent)),
+            max_concurrent,
+        }
+    }
+
+    /// Check if a block is currently being prefetched
+    pub fn is_pending(&self, namespace: &str, hash: &[u8]) -> bool {
+        let key = BlockKey::new(namespace.to_string(), hash.to_vec());
+        self.pending.contains_key(&key)
+    }
+
+    /// Try to acquire a prefetch slot. Returns None if at capacity.
+    pub fn try_acquire(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
+        Arc::clone(&self.semaphore).try_acquire_owned().ok()
+    }
+
+    /// Mark blocks as pending prefetch
+    fn mark_pending(&self, keys: &[BlockKey]) {
+        for key in keys {
+            self.pending.insert(key.clone(), ());
+        }
+    }
+
+    /// Remove blocks from pending set
+    fn clear_pending(&self, keys: &[BlockKey]) {
+        for key in keys {
+            self.pending.remove(key);
+        }
+    }
+
+    /// Get current pending count
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Get available permits
+    pub fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+}
+
+/// Spawn a background prefetch task from DFS into storage cache.
+///
+/// Returns immediately after spawning. Use tracker.is_pending() to check status.
+pub fn prefetch_blocks_from_dfs(
+    storage: Arc<StorageEngine>,
+    conn: MultiplexedConnection,
+    tracker: Arc<PrefetchTracker>,
+    dfs_root: PathBuf,
+    namespace: String,
+    hashes: Vec<Vec<u8>>,
+) {
+    if hashes.is_empty() {
+        return;
+    }
+
+    tokio::spawn(async move {
+        let mut conn = conn;
+        if let Err(e) =
+            prefetch_blocks_inner(&storage, &mut conn, &tracker, &dfs_root, &namespace, hashes)
+                .await
+        {
+            error!("Background prefetch failed: {}", e);
+        }
+    });
+}
+
+/// Internal prefetch implementation
+async fn prefetch_blocks_inner(
+    storage: &StorageEngine,
+    conn: &mut MultiplexedConnection,
+    tracker: &PrefetchTracker,
+    dfs_root: &Path,
+    namespace: &str,
+    hashes: Vec<Vec<u8>>,
+) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+    if hashes.is_empty() {
+        return Ok(0);
+    }
+
+    let start = Instant::now();
+    // Try to acquire a permit (max 16 concurrent)
+    let Some(permit) = tracker.try_acquire() else {
+        debug!(
+            "Prefetch rejected: at capacity ({})",
+            tracker.max_concurrent
+        );
+        return Ok(0);
+    };
+
+    // Filter out blocks already in cache or pending
+    let to_fetch: Vec<Vec<u8>> = hashes
+        .into_iter()
+        .filter(|h| !storage.cache_contains(namespace, h) && !tracker.is_pending(namespace, h))
+        .collect();
+
+    if to_fetch.is_empty() {
+        drop(permit);
+        return Ok(0);
+    }
+
+    // Query Redis for block metadata
+    let metas = batch_get_block_meta(conn, namespace, &to_fetch).await?;
+
+    // Collect blocks that have metadata in Redis
+    let mut blocks_to_load: Vec<(Vec<u8>, BlockMeta)> = Vec::new();
+    for (hash, meta_opt) in to_fetch.iter().zip(metas.into_iter()) {
+        if let Some(meta) = meta_opt {
+            blocks_to_load.push((hash.clone(), meta));
+        }
+    }
+
+    if blocks_to_load.is_empty() {
+        drop(permit);
+        return Ok(0);
+    }
+
+    // Mark as pending before spawning
+    let block_keys: Vec<BlockKey> = blocks_to_load
+        .iter()
+        .map(|(h, _)| BlockKey::new(namespace.to_string(), h.clone()))
+        .collect();
+    tracker.mark_pending(&block_keys);
+
+    info!(
+        namespace = %namespace,
+        blocks = blocks_to_load.len(),
+        "Starting DFS prefetch"
+    );
+
+    // Group by file for efficient reading
+    let mut by_file: HashMap<String, Vec<(Vec<u8>, BlockMeta)>> = HashMap::new();
+    for (hash, meta) in blocks_to_load {
+        by_file
+            .entry(meta.file.clone())
+            .or_default()
+            .push((hash, meta));
+    }
+
+    let mut total_loaded = 0usize;
+    let dfs_root = dfs_root.to_path_buf();
+    let ns = namespace.to_string();
+
+    for (file_name, file_blocks) in by_file {
+        match read_file_blocks(storage, &dfs_root, &ns, &file_name, file_blocks).await {
+            Ok(count) => total_loaded += count,
+            Err(e) => {
+                error!(file = %file_name, "Failed to read from DFS: {}", e);
+            }
+        }
+    }
+
+    // Clear pending status
+    tracker.clear_pending(&block_keys);
+    drop(permit);
+
+    let elapsed = start.elapsed();
+    info!(
+        namespace = %namespace,
+        loaded = total_loaded,
+        elapsed_ms = elapsed.as_secs_f64() * 1000.0,
+        "DFS prefetch complete"
+    );
+
+    Ok(total_loaded)
+}
+
+/// Read blocks from a single packed file and insert into cache
+async fn read_file_blocks(
+    storage: &StorageEngine,
+    dfs_root: &Path,
+    namespace: &str,
+    file_name: &str,
+    blocks: Vec<(Vec<u8>, BlockMeta)>,
+) -> Result<usize, std::io::Error> {
+    use std::num::NonZeroU64;
+    use std::os::unix::fs::FileExt;
+
+    let file_path = dfs_root.join(namespace).join(file_name);
+
+    // Sort by offset for sequential read pattern
+    let mut blocks = blocks;
+    blocks.sort_by_key(|(_, m)| m.offset);
+
+    let mut loaded = 0;
+
+    for (hash, meta) in blocks {
+        let block_size = meta.total_size();
+        let total_slots = meta.total_slots;
+
+        if total_slots == 0 || block_size == 0 {
+            warn!(
+                hash = %hex::encode(&hash),
+                "Skipping block with zero slots or size"
+            );
+            continue;
+        }
+
+        // Allocate pinned memory
+        let Some(allocation) = storage.allocate(NonZeroU64::new(block_size).unwrap()) else {
+            error!("Failed to allocate pinned memory for prefetch");
+            continue;
+        };
+
+        // Read from file into pinned memory
+        let file_path_clone = file_path.clone();
+        let offset = meta.offset;
+
+        let read_result = tokio::task::spawn_blocking({
+            let allocation = Arc::clone(&allocation);
+            move || {
+                let start_time = Instant::now();
+                let file = std::fs::File::open(&file_path_clone)?;
+                let buf = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        allocation.as_ptr() as *mut u8,
+                        block_size as usize,
+                    )
+                };
+                file.read_exact_at(buf, offset)?;
+                let elapsed = start_time.elapsed();
+                // calculate bandwitdth
+                let bandwidth = (block_size as f64 / 1e6) / elapsed.as_secs_f64();
+                info!(
+                    "Read block from file: {} , {} ms, {} MB/s",
+                    ByteSize(block_size),
+                    elapsed.as_millis(),
+                    bandwidth
+                );
+                Ok::<_, std::io::Error>(())
+            }
+        })
+        .await
+        .map_err(std::io::Error::other)?;
+
+        if let Err(e) = read_result {
+            error!(file = %file_name, offset = offset, "Failed to read block: {}", e);
+            continue;
+        }
+
+        // Rebuild SealedBlock from the read data
+        let sealed = rebuild_sealed_block(allocation, &meta)?;
+
+        // Insert into cache
+        storage.cache_insert(namespace, hash, Arc::new(sealed));
+        loaded += 1;
+    }
+
+    Ok(loaded)
+}
+
+/// Rebuild a SealedBlock from raw data and metadata
+fn rebuild_sealed_block(
+    allocation: Arc<crate::pinned_pool::PinnedAllocation>,
+    meta: &BlockMeta,
+) -> Result<SealedBlock, std::io::Error> {
+    let mut layer_blocks = Vec::with_capacity(meta.slots.len());
+    let base_ptr = allocation.as_ptr() as *mut u8;
+    let mut current_offset = 0usize;
+
+    for slot_meta in &meta.slots {
+        let slot_size = slot_meta.size as usize;
+
+        let layer_block = if slot_meta.is_split {
+            // Split storage: K and V are stored sequentially in the file
+            // but we need separate pointers
+            let half = slot_size / 2;
+            let k_ptr = unsafe { base_ptr.add(current_offset) };
+            let v_ptr = unsafe { base_ptr.add(current_offset + half) };
+
+            Arc::new(LayerBlock::new_split(
+                k_ptr,
+                v_ptr,
+                slot_size,
+                Arc::clone(&allocation),
+                Arc::clone(&allocation), // Same allocation for both K and V
+            ))
+        } else {
+            // Contiguous storage
+            let ptr = unsafe { base_ptr.add(current_offset) };
+            Arc::new(LayerBlock::new_contiguous(
+                ptr,
+                slot_size,
+                Arc::clone(&allocation),
+            ))
+        };
+
+        layer_blocks.push(layer_block);
+        current_offset += slot_size;
+    }
+
+    Ok(SealedBlock::from_slots(layer_blocks))
 }

--- a/pegaflow-proto/proto/engine.proto
+++ b/pegaflow-proto/proto/engine.proto
@@ -62,9 +62,26 @@ message QueryRequest {
   repeated bytes block_hashes = 2;
 }
 
+// Prefetch status enum
+enum PrefetchState {
+  // All requested blocks are in local cache
+  PREFETCH_READY = 0;
+  // Some blocks are being prefetched from DFS
+  PREFETCH_LOADING = 1;
+  // Some blocks don't exist in DFS either
+  PREFETCH_PARTIAL_MISS = 2;
+}
+
 message QueryResponse {
   ResponseStatus status = 1;
+  // Number of blocks ready in cache (for backwards compatibility)
   uint64 hit_blocks = 2;
+  // Prefetch state for async prefetch support
+  PrefetchState prefetch_state = 3;
+  // Number of blocks currently being loaded from DFS
+  uint64 loading_blocks = 4;
+  // Number of blocks not found in DFS
+  uint64 missing_blocks = 5;
 }
 
 message UnregisterRequest {

--- a/pegaflow-server/Cargo.toml
+++ b/pegaflow-server/Cargo.toml
@@ -34,6 +34,7 @@ opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true
 tikv-jemallocator.workspace = true
+redis.workspace = true
 
 [build-dependencies]
 pyo3-build-config.workspace = true

--- a/pegaflow-server/proto/engine.proto
+++ b/pegaflow-server/proto/engine.proto
@@ -62,9 +62,26 @@ message QueryRequest {
   repeated bytes block_hashes = 2;
 }
 
+// Prefetch status enum
+enum PrefetchState {
+  // All requested blocks are in local cache
+  PREFETCH_READY = 0;
+  // Some blocks are being prefetched from DFS
+  PREFETCH_LOADING = 1;
+  // Some blocks don't exist in DFS either
+  PREFETCH_PARTIAL_MISS = 2;
+}
+
 message QueryResponse {
   ResponseStatus status = 1;
+  // Number of blocks ready in cache (for backwards compatibility)
   uint64 hit_blocks = 2;
+  // Prefetch state for async prefetch support
+  PrefetchState prefetch_state = 3;
+  // Number of blocks currently being loaded from DFS
+  uint64 loading_blocks = 4;
+  // Number of blocks not found in DFS
+  uint64 missing_blocks = 5;
 }
 
 message UnregisterRequest {

--- a/pegaflow-server/src/service.rs
+++ b/pegaflow-server/src/service.rs
@@ -1,13 +1,14 @@
 use crate::proto::engine::engine_server::Engine;
 use crate::proto::engine::{
-    HealthRequest, HealthResponse, LoadRequest, LoadResponse, QueryRequest, QueryResponse,
-    RegisterContextRequest, RegisterContextResponse, ResponseStatus, SaveRequest, SaveResponse,
-    ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
+    HealthRequest, HealthResponse, LoadRequest, LoadResponse, PrefetchState, QueryRequest,
+    QueryResponse, RegisterContextRequest, RegisterContextResponse, ResponseStatus, SaveRequest,
+    SaveResponse, ShutdownRequest, ShutdownResponse, UnregisterRequest, UnregisterResponse,
 };
 use crate::registry::{CudaTensorRegistry, TensorMetadata};
 use parking_lot::Mutex;
-use pegaflow_core::{EngineError, PegaEngine};
+use pegaflow_core::{EngineError, PegaEngine, PrefetchStatus, PrefetchTracker};
 use pyo3::{PyErr, Python};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Notify;
 use tonic::{async_trait, Request, Response, Status};
@@ -18,6 +19,12 @@ pub struct GrpcEngineService {
     engine: Arc<PegaEngine>,
     registry: Arc<Mutex<CudaTensorRegistry>>,
     shutdown: Arc<Notify>,
+    /// Redis connection for DFS metadata lookup (None if DFS disabled)
+    redis_conn: Option<Arc<tokio::sync::Mutex<redis::aio::MultiplexedConnection>>>,
+    /// Prefetch tracker for DFS prefetch (None if DFS disabled)
+    prefetch_tracker: Option<Arc<PrefetchTracker>>,
+    /// DFS root directory (None if DFS disabled)
+    dfs_root: Option<PathBuf>,
 }
 
 impl GrpcEngineService {
@@ -30,6 +37,27 @@ impl GrpcEngineService {
             engine,
             registry,
             shutdown,
+            redis_conn: None,
+            prefetch_tracker: None,
+            dfs_root: None,
+        }
+    }
+
+    /// Create with DFS prefetch support
+    pub fn with_dfs(
+        engine: Arc<PegaEngine>,
+        registry: Arc<Mutex<CudaTensorRegistry>>,
+        shutdown: Arc<Notify>,
+        redis_conn: redis::aio::MultiplexedConnection,
+        dfs_root: PathBuf,
+    ) -> Self {
+        Self {
+            engine,
+            registry,
+            shutdown,
+            redis_conn: Some(Arc::new(tokio::sync::Mutex::new(redis_conn))),
+            prefetch_tracker: Some(Arc::new(PrefetchTracker::new(1024 * 1024 * 1024))), // max 16 concurrent prefetches
+            dfs_root: Some(dfs_root),
         }
     }
 
@@ -199,7 +227,7 @@ impl Engine for GrpcEngineService {
     }
 
     #[instrument(
-        level = "info",
+        level = "debug",
         skip(self, request),
         fields(instance=%request.get_ref().instance_id, blocks=%request.get_ref().block_hashes.len()),
         ret
@@ -209,15 +237,62 @@ impl Engine for GrpcEngineService {
         request: Request<QueryRequest>,
     ) -> Result<Response<QueryResponse>, Status> {
         let req = request.into_inner();
-        let hit_blocks = self
-            .engine
-            .count_prefix_hit_blocks(&req.instance_id, &req.block_hashes)
-            .map_err(Self::map_engine_error)?;
 
-        Ok(Response::new(QueryResponse {
-            status: Some(Self::build_simple_response()),
-            hit_blocks: hit_blocks as u64,
-        }))
+        // If DFS is enabled, use async prefetch-aware query
+        if let (Some(redis_conn), Some(tracker), Some(dfs_root)) =
+            (&self.redis_conn, &self.prefetch_tracker, &self.dfs_root)
+        {
+            let mut conn = redis_conn.lock().await;
+            let status = self
+                .engine
+                .count_prefix_hit_blocks_async(
+                    &req.instance_id,
+                    &req.block_hashes,
+                    &mut conn,
+                    tracker,
+                    dfs_root,
+                )
+                .await
+                .map_err(Self::map_engine_error)?;
+
+            let (prefetch_state, hit_blocks, loading_blocks, missing_blocks) = match status {
+                PrefetchStatus::Ready(n) => (PrefetchState::PrefetchReady, n as u64, 0, 0),
+                PrefetchStatus::Prefetching { ready, loading } => (
+                    PrefetchState::PrefetchLoading,
+                    ready as u64,
+                    loading as u64,
+                    0,
+                ),
+                PrefetchStatus::PartialMiss { ready, missing } => (
+                    PrefetchState::PrefetchPartialMiss,
+                    ready as u64,
+                    0,
+                    missing as u64,
+                ),
+            };
+
+            Ok(Response::new(QueryResponse {
+                status: Some(Self::build_simple_response()),
+                hit_blocks,
+                prefetch_state: prefetch_state.into(),
+                loading_blocks,
+                missing_blocks,
+            }))
+        } else {
+            // Fallback to sync query (no DFS)
+            let hit_blocks = self
+                .engine
+                .count_prefix_hit_blocks(&req.instance_id, &req.block_hashes)
+                .map_err(Self::map_engine_error)?;
+
+            Ok(Response::new(QueryResponse {
+                status: Some(Self::build_simple_response()),
+                hit_blocks: hit_blocks as u64,
+                prefetch_state: PrefetchState::PrefetchReady.into(),
+                loading_blocks: 0,
+                missing_blocks: 0,
+            }))
+        }
     }
 
     #[instrument(


### PR DESCRIPTION
- Introduce `seal_offload` module for tasks
- StorageEngine notifies on sealed block sealing
- PegaEngine exposes seal notification channel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces durable DFS offload and async prefetch across the stack, with minimal API changes for callers.
> 
> - Core: new `seal_offload` module to pack sealed blocks to DFS (`{namespace}/{uuid}.bin`), write metadata to Redis, and enforce quotas with LRU eviction; `StorageEngine` now emits `SealNotification` and provides `cache_insert`; `PegaEngine` holds `Arc<StorageEngine>` and `new_with_config` returns `(engine, seal_notify_rx)`; adds async `count_prefix_hit_blocks_async` with `PrefetchStatus` and `PrefetchTracker`, and DFS prefetch (`prefetch_blocks_from_dfs`).
> - Server: adds CLI flags (`--redis_url`, `--dfs_root`, `--dfs_quota`, `--dfs_scan_interval_ms`); when Redis is set, spawns offload tasks and enables prefetch-aware `query`; otherwise falls back to sync path.
> - Proto: extends `QueryResponse` with `PrefetchState` and fields `hit_blocks`, `prefetch_state`, `loading_blocks`, `missing_blocks` (mirrored in both proto copies).
> - Python: `engine.query` now returns a dict including `prefetch_state`/counts; scheduler handles "loading" by retrying and logs partial misses.
> - Example/other: updates `examples/bench_kv_cache.py` to set `--block-size 64`; adds dependencies (`redis`, `hex`, `combine`, etc.) and wires workspace crates accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87aeadefa88ebbbd46e4fc1d414ad1039fd439bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->