### PR TITLE
feat(connector): add configurable KV save admission prob

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -23,6 +23,7 @@ from pegaflow.connector.common import (
     derive_namespace,
     logger,
     resolve_instance_id,
+    resolve_save_admission_prob,
 )
 from pegaflow.connector.scheduler import SchedulerConnector
 from pegaflow.connector.worker import WorkerConnector
@@ -43,6 +44,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             vllm_config.model_config.hf_text_config, "num_hidden_layers", 0
         )
         block_size = vllm_config.cache_config.block_size
+        save_admission_prob = resolve_save_admission_prob()
 
         tp_rank: Optional[int] = None
         device_id: Optional[int] = None
@@ -66,6 +68,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             tp_rank=tp_rank,
             device_id=device_id,
             engine_client=engine_client,
+            save_admission_prob=save_admission_prob,
         )
 
         self._scheduler: SchedulerConnector | None = None
@@ -76,7 +79,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             self._worker = WorkerConnector(self._ctx)
 
         logger.info(
-            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s tp_rank=%s tp_size=%d layers=%d namespace=%s",
+            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s tp_rank=%s tp_size=%d layers=%d namespace=%s save_prob=%.3f",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
@@ -84,6 +87,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             tp_size,
             num_layers,
             namespace,
+            save_admission_prob,
         )
 
     # ==============================

--- a/python/pegaflow/connector/common.py
+++ b/python/pegaflow/connector/common.py
@@ -17,6 +17,8 @@ logger = get_connector_logger()
 
 # Engine server endpoint (gRPC URL)
 ENGINE_ENDPOINT = os.environ.get("PEGAFLOW_ENGINE_ENDPOINT", "http://127.0.0.1:50055")
+SAVE_ADMISSION_ENV = "PEGAFLOW_SAVE_ADMISSION_PROB"
+DEFAULT_SAVE_ADMISSION_PROB = 1.0
 
 
 @dataclass(frozen=True)
@@ -31,6 +33,7 @@ class ConnectorContext:
     tp_rank: int | None
     device_id: int | None
     engine_client: EngineRpcClient
+    save_admission_prob: float
 
 
 class RequestPhase(enum.Enum):
@@ -126,6 +129,7 @@ class RequestTracker:
         "_stored_blocks",
         "_total_layers",
         "_saved_layers",
+        "_save_admitted",
         "_finished",
     )
 
@@ -135,6 +139,7 @@ class RequestTracker:
         block_hashes: list[bytes],
         block_size: int,
         num_layers: int,
+        save_admitted: bool = True,
     ):
         self.request_id = request_id
         self._block_hashes = tuple(block_hashes)
@@ -144,7 +149,8 @@ class RequestTracker:
         self._scheduled_tokens: int = 0
         self._stored_blocks: int = 0
         self._total_layers = num_layers
-        self._saved_layers: int = 0
+        self._saved_layers: int = 0 if save_admitted else num_layers
+        self._save_admitted = save_admitted
         self._finished: bool = False
 
     @property
@@ -160,6 +166,10 @@ class RequestTracker:
     @property
     def num_blocks(self) -> int:
         return len(self._block_hashes)
+
+    @property
+    def save_admitted(self) -> bool:
+        return self._save_admitted
 
     def on_lookup(self, hit_blocks: int, computed_blocks: int) -> None:
         """New lookup = fresh load state. Handles preemption implicitly."""
@@ -187,12 +197,18 @@ class RequestTracker:
         self._scheduled_tokens += num_tokens
 
     def on_layer_saved(self) -> None:
-        self._saved_layers += 1
+        if not self._save_admitted:
+            return
+        if self._saved_layers < self._total_layers:
+            self._saved_layers += 1
 
     def on_finished(self) -> None:
         self._finished = True
 
     def consume_save_intent(self) -> SaveIntent | None:
+        if not self._save_admitted:
+            return None
+
         saveable = min(
             len(self._block_hashes),
             len(self._allocated_blocks),
@@ -223,7 +239,8 @@ class RequestTracker:
         return (
             f"RequestTracker({self.request_id}, {self.phase.value}, "
             f"load={self._load}, alloc={len(self._allocated_blocks)}, "
-            f"stored={self._stored_blocks}, saved={self._saved_layers}/{self._total_layers})"
+            f"stored={self._stored_blocks}, saved={self._saved_layers}/{self._total_layers}, "
+            f"save_admitted={self._save_admitted})"
         )
 
 
@@ -280,6 +297,47 @@ def resolve_instance_id(vllm_config, dp_rank_suffix: bool = True) -> str:
     return instance_id
 
 
+def resolve_save_admission_prob() -> float:
+    """
+    Resolve save admission probability from env.
+
+    Accepts a float in [0, 1]. Values >1 are treated as percentages (divided by 100).
+    Clamps to [0, 1] and falls back to DEFAULT_SAVE_ADMISSION_PROB on parse errors.
+    """
+    raw = os.environ.get(SAVE_ADMISSION_ENV)
+    if raw is None or raw == "":
+        return DEFAULT_SAVE_ADMISSION_PROB
+
+    try:
+        prob = float(raw)
+    except ValueError:
+        logger.warning(
+            "[PegaKVConnector] Invalid %s=%s; using default %.2f",
+            SAVE_ADMISSION_ENV,
+            raw,
+            DEFAULT_SAVE_ADMISSION_PROB,
+        )
+        return DEFAULT_SAVE_ADMISSION_PROB
+
+    if prob > 1.0:
+        prob = prob / 100.0
+        logger.info(
+            "[PegaKVConnector] Interpreting %s as percentage: %.4f",
+            SAVE_ADMISSION_ENV,
+            prob,
+        )
+
+    clamped = max(0.0, min(prob, 1.0))
+    if clamped != prob:
+        logger.warning(
+            "[PegaKVConnector] Clamped %s to %.2f (raw=%.4f)",
+            SAVE_ADMISSION_ENV,
+            clamped,
+            prob,
+        )
+    return clamped
+
+
 def derive_namespace(vllm_config, tp_size: int) -> str:
     """
     Derive namespace for storage isolation.
@@ -314,4 +372,5 @@ __all__ = [
     "derive_namespace",
     "logger",
     "resolve_instance_id",
+    "resolve_save_admission_prob",
 ]

--- a/python/pegaflow/connector/scheduler.py
+++ b/python/pegaflow/connector/scheduler.py
@@ -3,6 +3,7 @@ Scheduler-side connector logic.
 """
 
 import time
+import random
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,8 @@ class SchedulerConnector:
 
     def __init__(self, context: ConnectorContext):
         self._ctx = context
+        self._save_admission_prob = context.save_admission_prob
+        self._rng = random.Random()
         self._trackers: dict[str, RequestTracker] = {}
         self._pending_load_intents: dict[str, LoadIntent] = {}
         self._held_requests: set[str] = set()
@@ -193,6 +196,10 @@ class SchedulerConnector:
         if tracker:
             tracker.on_finished()
 
+            if not tracker.save_admitted:
+                del self._trackers[req_id]
+                return (False, None)
+
             if tracker.should_hold_blocks():
                 self._held_requests.add(req_id)
                 logger.debug(
@@ -206,12 +213,25 @@ class SchedulerConnector:
     def _get_or_create_tracker(self, request: "Request") -> RequestTracker:
         req_id = request.request_id
         if req_id not in self._trackers:
-            self._trackers[req_id] = RequestTracker(
+            save_admitted = (
+                self._save_admission_prob >= 1.0
+                or self._rng.random() < self._save_admission_prob
+            )
+            tracker = RequestTracker(
                 request_id=req_id,
                 block_hashes=list(request.block_hashes),
                 block_size=self._ctx.block_size,
                 num_layers=self._ctx.num_layers,
+                save_admitted=save_admitted,
             )
+            self._trackers[req_id] = tracker
+
+            if not save_admitted:
+                logger.info(
+                    "[PegaKVConnector] Request %s skipped KV save (p=%.2f)",
+                    req_id,
+                    self._save_admission_prob,
+                )
         return self._trackers[req_id]
 
     def _count_available_block_prefix(self, block_hashes: Iterable[bytes]) -> int:


### PR DESCRIPTION
- Implement random admission for KV block saving
- Configure save probability via PEGAFLOW_SAVE_ADMISSION_PROB
- Update RequestTracker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable, probabilistic admission for KV cache saving and threads it through scheduler/worker flow.
> 
> - Adds `PEGAFLOW_SAVE_ADMISSION_PROB` with robust parsing (`resolve_save_admission_prob`): supports 0–1, percentage inputs (>1), and clamping; default 1.0
> - Propagates `save_admission_prob` via `ConnectorContext`; logs `save_prob` at connector init
> - Scheduler samples per request to set `save_admitted`; skips save/hold when not admitted and logs decision
> - `RequestTracker` now respects `save_admitted`: initializes saved layer count, gates `on_layer_saved`/`consume_save_intent`, phase, and `__repr__`
> - Public exports/imports updated to include new resolver; minor logging tweaks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97471bb751d5f567b190844ab8e2e6fa057eb704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->