### PR TITLE
Revert "feat(connector): add configurable KV save admission prob (#19)"

### DIFF
--- a/python/pegaflow/connector/__init__.py
+++ b/python/pegaflow/connector/__init__.py
@@ -23,7 +23,6 @@ from pegaflow.connector.common import (
     derive_namespace,
     logger,
     resolve_instance_id,
-    resolve_save_admission_prob,
 )
 from pegaflow.connector.scheduler import SchedulerConnector
 from pegaflow.connector.worker import WorkerConnector
@@ -44,7 +43,6 @@ class PegaKVConnector(KVConnectorBase_V1):
             vllm_config.model_config.hf_text_config, "num_hidden_layers", 0
         )
         block_size = vllm_config.cache_config.block_size
-        save_admission_prob = resolve_save_admission_prob()
 
         tp_rank: Optional[int] = None
         device_id: Optional[int] = None
@@ -68,7 +66,6 @@ class PegaKVConnector(KVConnectorBase_V1):
             tp_rank=tp_rank,
             device_id=device_id,
             engine_client=engine_client,
-            save_admission_prob=save_admission_prob,
         )
 
         self._scheduler: SchedulerConnector | None = None
@@ -79,7 +76,7 @@ class PegaKVConnector(KVConnectorBase_V1):
             self._worker = WorkerConnector(self._ctx)
 
         logger.info(
-            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s tp_rank=%s tp_size=%d layers=%d namespace=%s save_prob=%.3f",
+            "[PegaKVConnector] Initialized role=%s instance_id=%s device=%s tp_rank=%s tp_size=%d layers=%d namespace=%s",
             role.name,
             instance_id,
             device_id if device_id is not None else "cpu",
@@ -87,7 +84,6 @@ class PegaKVConnector(KVConnectorBase_V1):
             tp_size,
             num_layers,
             namespace,
-            save_admission_prob,
         )
 
     # ==============================


### PR DESCRIPTION
This reverts commit a098fb75b25e6875fe48ac479a23b5be9eac3508.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the KV save admission probability feature and simplifies connector flow.
> 
> - Drops `save_admission_prob` from `ConnectorContext` and `RequestTracker`; removes `resolve_save_admission_prob()` and related env variables
> - Scheduler no longer random-admits saves; all requests are eligible for save/hold, and associated logging strings are updated
> - `RequestTracker` always increments saved layers and generates `SaveIntent` when eligible; repr/log messages adjusted accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8462f6c2e54cbdcd8f85e0d6f8f6eb3755b76a31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->